### PR TITLE
Add DrBimmer OS skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# DB
+# DrBimmer OS
+
+DrBimmer OS is a local operating system for auto repair shops providing offline-capable AI powered services. This monorepo contains the backend API, frontend dashboard, AI agents, and installer scripts.
+
+See individual directories for details.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent package for DrBimmer OS."""
+
+from .pitcrew import PitCrew
+
+__all__ = ["PitCrew"]

--- a/agents/pitcrew.py
+++ b/agents/pitcrew.py
@@ -1,0 +1,10 @@
+"""Simple local agent placeholder."""
+from typing import Any
+
+
+class PitCrew:
+    """Local diagnostic agent."""
+
+    def diagnose(self, data: Any) -> str:
+        """Return a basic diagnostic response."""
+        return "Diagnostics complete"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,9 @@
+# DrBimmer Backend
+
+This is a FastAPI application providing business logic and data access for DrBimmer OS.
+
+## Development
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+from .utils import add
+
+app = FastAPI(title="DrBimmer OS API")
+
+@app.get("/")
+def read_root():
+    """Root endpoint for health check."""
+    return {"message": "DrBimmer OS API running"}
+
+@app.get("/add/{a}/{b}")
+def add_numbers(a: int, b: int):
+    """Simple addition endpoint used for testing."""
+    return {"result": add(a, b)}

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,7 @@
+"""Utility functions used across the backend."""
+from typing import Any
+
+
+def add(a: Any, b: Any) -> Any:
+    """Return the sum of *a* and *b*."""
+    return a + b

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+python-jose[cryptography]
+passlib[bcrypt]
+psycopg2-binary

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'app'))
+from utils import add
+
+
+def test_add_integers():
+    assert add(1, 2) == 3
+
+
+def test_add_strings():
+    assert add("a", "b") == "ab"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: drbimmer
+      POSTGRES_PASSWORD: drbimmer
+      POSTGRES_DB: drbimmer
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend/app:/app/app
+    environment:
+      DATABASE_URL: postgresql://drbimmer:drbimmer@db:5432/drbimmer
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-slim as build
+WORKDIR /usr/src/app
+COPY package.json ./
+RUN npm install --production=false
+COPY src ./src
+RUN npx vite build --outDir /dist
+
+FROM nginx:alpine
+COPY --from=build /dist /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# DrBimmer Frontend
+
+React dashboard served via Vite.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "drbimmer-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>DrBimmer OS Dashboard</h1>
+      <p>Welcome to the offline auto shop management system.</p>
+    </div>
+  );
+}
+
+export default App;

--- a/installer/setup.sh
+++ b/installer/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Basic setup script for DrBimmer OS
+
+if ! command -v docker > /dev/null; then
+  echo "Docker is required. Please install Docker." >&2
+  exit 1
+fi
+
+if ! command -v docker-compose > /dev/null; then
+  echo "Docker Compose is required. Please install docker-compose." >&2
+  exit 1
+fi
+
+echo "Starting DrBimmer OS containers..."
+docker-compose up -d
+
+echo "Initialization complete. Access the system via https://localhost"


### PR DESCRIPTION
## Summary
- initialize DrBimmer OS monorepo with backend, frontend, agents and installer
- add FastAPI backend with simple utility module and tests
- add React-based frontend skeleton
- add Docker compose configuration and Dockerfiles
- provide installer setup script and initial documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a55fbf1c88324858bb19cef4a735b